### PR TITLE
Allow setting GOOGLETEST_PATH cmake argument.

### DIFF
--- a/cmake/GoogleTest.cmake
+++ b/cmake/GoogleTest.cmake
@@ -2,7 +2,10 @@
 set(GOOGLETEST_PREFIX "${benchmark_BINARY_DIR}/third_party/googletest")
 configure_file(${benchmark_SOURCE_DIR}/cmake/GoogleTest.cmake.in ${GOOGLETEST_PREFIX}/CMakeLists.txt @ONLY)
 
-set(GOOGLETEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/googletest") # Mind the quotes
+if(NOT GOOGLETEST_PATH)
+  set(GOOGLETEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/googletest") # Mind the quotes
+endif()
+
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
   -DALLOW_DOWNLOADING_GOOGLETEST=${BENCHMARK_DOWNLOAD_DEPENDENCIES} -DGOOGLETEST_PATH:PATH=${GOOGLETEST_PATH} .
   RESULT_VARIABLE result

--- a/cmake/GoogleTest.cmake
+++ b/cmake/GoogleTest.cmake
@@ -2,10 +2,7 @@
 set(GOOGLETEST_PREFIX "${benchmark_BINARY_DIR}/third_party/googletest")
 configure_file(${benchmark_SOURCE_DIR}/cmake/GoogleTest.cmake.in ${GOOGLETEST_PREFIX}/CMakeLists.txt @ONLY)
 
-if(NOT GOOGLETEST_PATH)
-  set(GOOGLETEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/googletest") # Mind the quotes
-endif()
-
+set(GOOGLETEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/googletest" CACHE PATH "") # Mind the quotes
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}"
   -DALLOW_DOWNLOADING_GOOGLETEST=${BENCHMARK_DOWNLOAD_DEPENDENCIES} -DGOOGLETEST_PATH:PATH=${GOOGLETEST_PATH} .
   RESULT_VARIABLE result


### PR DESCRIPTION
This change is necessary to allow setting GOOGLETEST_PATH from cmake argument, otherwise the following will not work:

$cmake -DGOOGLETEST_PATH=$HOME/googletest

-- Looking for Google Test sources in /home/alian/Desktop/Projects/etf-framework/submodules/benchmark/googletest
CMake Error at CMakeLists.txt:34 (message):
  Did not find Google Test sources! Either pass correct path in
  GOOGLETEST_PATH, or enable ALLOW_DOWNLOADING_GOOGLETEST, or disable
  BENCHMARK_ENABLE_GTEST_TESTS / BENCHMARK_ENABLE_TESTING.